### PR TITLE
Add 'disableHostCheck' in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3088,7 +3088,8 @@
           "optional": true
         },
         "webpack-dev-server": {
-          "optional": true
+          "optional": true,
+          "disableHostCheck": true
         },
         "webpack-hot-middleware": {
           "optional": true


### PR DESCRIPTION
Add 'disableHostCheck' in package-lock.json to fix "Invalid Host header" error in deployment